### PR TITLE
Run migration from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ And update config.exs
 
 ```elixir
   config :ktsllex,
-    # Should it run the migration when called? Default: true
-    run_migrations: true,
+    # Should it run the migration when called? Default: false
+    run_migrations: false,
     schema_registry_host: {:system, "AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", "http://localhost:8081"},
     # Reads the yaml schema file from :
     base_path: {:system, "KAFKA_SCHEMA_BASE_PATH", "./schemas"},

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ mix create_schemas --host=localhost:8081 --schema=schema_name --base=./path/to
 $ mix create_topics --host=localhost:3030 --user=admin --password=admin --topic=topic_name
 ```
 
-### `--base`
+* `--base`
 
 The path to the schema files is passed into `mix create_schemas` via `--base=./path/to/schemas/json`.
 
@@ -38,7 +38,7 @@ Then there should be two flies in ./schemas:
 * `./schemas-key.json`
 * `./schemas-value.json`
 
-### `--schema`
+* `--schema`
 
 The `-key` and `-value` schemas get updated based on the `schema` parameter
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Kafka Topic and Schema creator
 
-## Usage
+## Setup
 
 Add `ktsllex` to your `deps` list :
 ```elixir
@@ -14,12 +14,48 @@ Add `ktsllex` to your `deps` list :
 
 Run `mix do deps.get, deps.compile`
 
-Now you have access to `create_schemas` and `create_topics` mix tasks, eg:
+### Auto migrations
+
+To have it run schema migrations at application boot time.
+
+Add `ktsllex` to your app boot sequence. After logger, and before any schema reading apps.
+
+```elixir
+      extra_applications: [
+        :logger,
+        ...
+        :ktsllex,
+        ...
+        :event_serializer
+```
+
+And update config.exs
+
+```elixir
+  config :ktsllex,
+    # Should it run the migration when called? Default: true
+    run_migrations: true,
+    schema_registry_host: "http://localhost:8081",
+    schema_name: "schema_name",
+    # Need to know where the app is to get the path to the schema files
+    app_name: :your_otp_app_name,
+    base_path: "./schemas/file/location",
+    lenses_host: "http://localhost:3030",
+    lenses_user: "admin",
+    lenses_pass: "admin",
+    lenses_topic: "lenses_topic"
+```
+
+## Usage
+
+You have access to `create_schemas` and `create_topics` mix tasks, eg:
 
 ```bash
 $ mix create_schemas --host=localhost:8081 --schema=schema_name --base=./path/to/schemas/json
 $ mix create_topics --host=localhost:3030 --user=admin --password=admin --topic=topic_name
 ```
+
+### Options
 
 * `--base`
 

--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ And update config.exs
 
 ```elixir
   config :ktsllex,
-    # Should it run the migration when called? Default: true
+    # Should it run the migration when called? Default: true
     run_migrations: true,
-    schema_registry_host: "http://localhost:8081",
-    schema_name: "schema_name",
-    # Need to know where the app is to get the path to the schema files
-    app_name: :your_otp_app_name,
-    base_path: "./schemas/file/location",
-    lenses_host: "http://localhost:3030",
-    lenses_user: "admin",
-    lenses_pass: "admin",
-    lenses_topic: "lenses_topic"
+    schema_registry_host: {:system, "AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", "http://localhost:8081"},
+    # Reads the yaml schema file from :
+    base_path: {:system, "KAFKA_SCHEMA_BASE_PATH", "./schemas"},
+    schema_name: {:system, "KAFKA_SCHEMA_NAME", "schema_name"},
+    app_name: :app,
+    lenses_host: {:system, "LENSES_HOST", "http://localhost:3030"},
+    lenses_user: {:system, "LENSES_USER", "admin"},
+    lenses_pass: {:system, "LENSES_PASS", "admin"},
+    lenses_topic: {:system, "LENSES_TOPIC", "topic_name"}
 ```
 
 ## Usage

--- a/config/config.exs
+++ b/config/config.exs
@@ -14,12 +14,12 @@ config :ktsllex, Ktsllex.Topics, http_client: HTTPoison
 config :ktsllex,
   # Should it run the migration when called? Default: true
   run_migrations: true,
-  schema_registry_host: "http://localhost:8081",
-  schema_name: "schema_name",
-  # Need to know where the app is to get the path to the schema files
-  app_name: :your_otp_app_name,
-  base_path: "./schemas/file/location",
-  lenses_host: "http://localhost:3030",
-  lenses_user: "admin",
-  lenses_pass: "admin",
-  lenses_topic: "lenses_topic"
+  schema_registry_host: {:system, "AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", "http://localhost:8081"},
+  # Reads the yaml schema file from :
+  base_path: {:system, "KAFKA_SCHEMA_BASE_PATH", "./schemas"},
+  schema_name: {:system, "KAFKA_SCHEMA_NAME", "schema_name"},
+  app_name: :app,
+  lenses_host: {:system, "LENSES_HOST", "http://localhost:3030"},
+  lenses_user: {:system, "LENSES_USER", "admin"},
+  lenses_pass: {:system, "LENSES_PASS", "admin"},
+  lenses_topic: {:system, "LENSES_TOPIC", "topic_name"}

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,3 +10,16 @@ use Mix.Config
 
 config :ktsllex, Ktsllex.Schemas, http_client: HTTPoison
 config :ktsllex, Ktsllex.Topics, http_client: HTTPoison
+
+config :ktsllex,
+  # Should it run the migration when called? Default: true
+  run_migrations: true,
+  schema_registry_host: "http://localhost:8081",
+  schema_name: "schema_name",
+  # Need to know where the app is to get the path to the schema files
+  app_name: :your_otp_app_name,
+  base_path: "./schemas/file/location",
+  lenses_host: "http://localhost:3030",
+  lenses_user: "admin",
+  lenses_pass: "admin",
+  lenses_topic: "lenses_topic"

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,7 @@ config :ktsllex,
   # Reads the yaml schema file from :
   base_path: {:system, "KAFKA_SCHEMA_BASE_PATH", "./schemas"},
   schema_name: {:system, "KAFKA_SCHEMA_NAME", "schema_name"},
-  app_name: :app,
+  app_name: :ktsllex,
   lenses_host: {:system, "LENSES_HOST", "http://localhost:3030"},
   lenses_user: {:system, "LENSES_USER", "admin"},
   lenses_pass: {:system, "LENSES_PASS", "admin"},

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,8 +12,8 @@ config :ktsllex, Ktsllex.Schemas, http_client: HTTPoison
 config :ktsllex, Ktsllex.Topics, http_client: HTTPoison
 
 config :ktsllex,
-  # Should it run the migration when called? Default: true
-  run_migrations: true,
+  # Should it run the migration when called? Default: false
+  run_migrations: false,
   schema_registry_host: {:system, "AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", "http://localhost:8081"},
   # Reads the yaml schema file from :
   base_path: {:system, "KAFKA_SCHEMA_BASE_PATH", "./schemas"},

--- a/lib/ktsllex/config.ex
+++ b/lib/ktsllex/config.ex
@@ -1,6 +1,6 @@
 defmodule Ktsllex.Config do
   @moduledoc """
-  This updates the config for schemas
+  This updates the Kafka config for schemas
   """
 
   use Confex, otp_app: :ktsllex

--- a/lib/ktsllex/ktsllex.ex
+++ b/lib/ktsllex/ktsllex.ex
@@ -1,0 +1,23 @@
+defmodule Ktsllex do
+  use Application
+
+  @moduledoc """
+  If the client application wants to run the schema migrations at boot
+
+  ```elixir
+        extra_applications: [
+          :logger,
+          ...
+          :ktsllex,
+          ...
+          :event_serializer
+  ```
+  """
+
+  @spec start(any(), any()) :: :ignore | {:error, any()} | {:ok, pid()}
+  def start(_type, _args) do
+    Ktsllex.Schema.Migration.run()
+
+    Supervisor.start_link([], strategy: :one_for_one)
+  end
+end

--- a/lib/ktsllex/ktsllex.ex
+++ b/lib/ktsllex/ktsllex.ex
@@ -16,8 +16,8 @@ defmodule Ktsllex do
 
   @spec start(any(), any()) :: :ignore | {:error, any()} | {:ok, pid()}
   def start(_type, _args) do
+    Confex.resolve_env!(:ktsllex)
     Ktsllex.Schema.Migration.run()
-
     Supervisor.start_link([], strategy: :one_for_one)
   end
 end

--- a/lib/ktsllex/migration.ex
+++ b/lib/ktsllex/migration.ex
@@ -1,0 +1,52 @@
+defmodule Ktsllex.Schema.Migration do
+  @moduledoc """
+  Creates the Kafka schemas and topics as required by config
+
+  ```elixir
+  config :ktsllex,
+    # Should it run the migration when called? Default: true
+    run_migrations: true,
+    schema_registry_host: "http://localhost:8081",
+    schema_name: "schema_name",
+    # Need to know where the app is to get the path to the schema files
+    app_name: :your_otp_app_name,
+    base_path: "./schemas/file/location",
+    lenses_host: "http://localhost:3030",
+    lenses_user: "admin",
+    lenses_pass: "admin",
+    lenses_topic: "lenses_topic"
+  ```
+  """
+
+  require Logger
+
+  @spec run() :: :ok
+  def run(), do: run_migrations?() |> perform()
+
+  defp perform(true) do
+    base_path() |> IO.inspect(label: "base_path")
+
+    Ktsllex.Schemas.run(schema_registry_host(), schema_name(), schema_path())
+    Ktsllex.Topics.run(lenses_host(), lenses_user(), lenses_pass(), lenses_topic())
+
+    :ok
+  end
+
+  defp perform(_), do: Logger.info("#{__MODULE__} schema migration disabled")
+
+  defp schema_path(), do: app_path() <> "/" <> base_path()
+
+  defp app_path(), do: :code.priv_dir(app_name()) |> to_string()
+
+  defp run_migrations?, do: Application.get_env(:ktsllex, :run_migrations, false)
+
+  defp schema_registry_host, do: Application.get_env(:ktsllex, :schema_registry_host)
+  defp schema_name, do: Application.get_env(:ktsllex, :schema_name)
+  defp app_name, do: Application.get_env(:ktsllex, :app_name)
+  defp base_path, do: Application.get_env(:ktsllex, :base_path)
+
+  defp lenses_host, do: Application.get_env(:ktsllex, :lenses_host)
+  defp lenses_user, do: Application.get_env(:ktsllex, :lenses_user)
+  defp lenses_pass, do: Application.get_env(:ktsllex, :lenses_pass)
+  defp lenses_topic, do: Application.get_env(:ktsllex, :lenses_topic)
+end

--- a/lib/ktsllex/migration.ex
+++ b/lib/ktsllex/migration.ex
@@ -34,7 +34,7 @@ defmodule Ktsllex.Schema.Migration do
 
   defp schema_path(), do: app_path() <> "/" <> base_path()
 
-  defp app_path(), do: :code.priv_dir(app_name()) |> to_string()
+  defp app_path(), do: app_name() |> :code.priv_dir() |> to_string()
 
   defp run_migrations?, do: Application.get_env(:ktsllex, :run_migrations, false)
 

--- a/lib/ktsllex/migration.ex
+++ b/lib/ktsllex/migration.ex
@@ -3,18 +3,18 @@ defmodule Ktsllex.Schema.Migration do
   Creates the Kafka schemas and topics as required by config
 
   ```elixir
-  config :ktsllex,
-    # Should it run the migration when called? Default: true
-    run_migrations: true,
-    schema_registry_host: "http://localhost:8081",
-    schema_name: "schema_name",
-    # Need to know where the app is to get the path to the schema files
-    app_name: :your_otp_app_name,
-    base_path: "./schemas/file/location",
-    lenses_host: "http://localhost:3030",
-    lenses_user: "admin",
-    lenses_pass: "admin",
-    lenses_topic: "lenses_topic"
+    config :ktsllex,
+      # Should it run the migration when called? Default: true
+      run_migrations: true,
+      schema_registry_host: {:system, "AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", "http://localhost:8081"},
+      # Reads the yaml schema file from :
+      base_path: {:system, "KAFKA_SCHEMA_BASE_PATH", "./schemas"},
+      schema_name: {:system, "KAFKA_SCHEMA_NAME", "schema_name"},
+      app_name: :app,
+      lenses_host: {:system, "LENSES_HOST", "http://localhost:3030"},
+      lenses_user: {:system, "LENSES_USER", "admin"},
+      lenses_pass: {:system, "LENSES_PASS", "admin"},
+      lenses_topic: {:system, "LENSES_TOPIC", "topic_name"}
   ```
   """
 

--- a/lib/ktsllex/migration.ex
+++ b/lib/ktsllex/migration.ex
@@ -4,8 +4,8 @@ defmodule Ktsllex.Schema.Migration do
 
   ```elixir
     config :ktsllex,
-      # Should it run the migration when called? Default: true
-      run_migrations: true,
+      # Should it run the migration when called? Default: false
+      run_migrations: false,
       schema_registry_host: {:system, "AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", "http://localhost:8081"},
       # Reads the yaml schema file from :
       base_path: {:system, "KAFKA_SCHEMA_BASE_PATH", "./schemas"},

--- a/lib/ktsllex/migration.ex
+++ b/lib/ktsllex/migration.ex
@@ -24,8 +24,6 @@ defmodule Ktsllex.Schema.Migration do
   def run(), do: run_migrations?() |> perform()
 
   defp perform(true) do
-    base_path() |> IO.inspect(label: "base_path")
-
     Ktsllex.Schemas.run(schema_registry_host(), schema_name(), schema_path())
     Ktsllex.Topics.run(lenses_host(), lenses_user(), lenses_pass(), lenses_topic())
 

--- a/lib/ktsllex/schemas.ex
+++ b/lib/ktsllex/schemas.ex
@@ -66,8 +66,7 @@ defmodule Ktsllex.Schemas do
         |> post(schema)
         |> extract_body()
         |> Poison.decode!()
-        |> inspect
-        |> IO.puts()
+        |> output_result()
     end
   end
 
@@ -118,6 +117,10 @@ defmodule Ktsllex.Schemas do
   end
 
   defp extract_body({:ok, %HTTPoison.Response{body: body}}), do: body
+
+  defp output_result(result) do
+    Logger.info("#{__MODULE__} created schema #{inspect(result)}")
+  end
 
   defp http_client(), do: config()[:http_client] || HTTPoison
 end

--- a/lib/ktsllex/schemas.ex
+++ b/lib/ktsllex/schemas.ex
@@ -47,7 +47,11 @@ defmodule Ktsllex.Schemas do
   ```
   """
   def run(host, schema_name, base_schema_file) do
-    Application.ensure_started(:logger)
+    Logger.info(
+      "#{__MODULE__} Creating schemas on:#{inspect(host)} with name:#{inspect(schema_name)} from:#{
+        inspect(base_schema_file)
+      }"
+    )
 
     ["-key", "-value"]
     |> Enum.map(fn type -> process(host, schema_name, base_schema_file, type) end)

--- a/lib/ktsllex/topics.ex
+++ b/lib/ktsllex/topics.ex
@@ -21,8 +21,9 @@ defmodule Ktsllex.Topics do
 
   """
   def run(host, user, password, topic_name, replication \\ 1, partitions \\ 1) do
-    Application.ensure_started(:logger)
-    Logger.info("#{__MODULE__} host:#{inspect(host)}")
+    Logger.info(
+      "#{__MODULE__} Creating topic on host:#{inspect(host)} with name:#{inspect(topic_name)}"
+    )
 
     host
     |> login().get_token(user, password)

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,8 @@ defmodule Ktsllex.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: []
+      mod: {Ktsllex, []},
+      extra_applications: [:logger]
     ]
   end
 

--- a/test/ktsllex/topics_test.exs
+++ b/test/ktsllex/topics_test.exs
@@ -4,8 +4,8 @@ defmodule Ktsllex.TopicsTest do
   alias Ktsllex.Topics, as: Subject
 
   defmodule LoginMock do
-    def get_token(host, user, "correct"), do: "mock_token"
-    def get_token(host, user, "wrong"), do: :error
+    def get_token(_host, _user, "correct"), do: "mock_token"
+    def get_token(_host, _user, "wrong"), do: :error
   end
 
   defmodule HTTPoisonMock do


### PR DESCRIPTION
Up until now, the user of this package has had to write code to perform the migrations, either within a script to use the mix tasks or code to call the migrations directly.

This PR starts this package as an OTP app, which reads in user-defined config and then calls the migrations directly for the user.

Another benefit is that now this can be started/ran _before_ any schema caching application, eg `event_serializer`, such that when the caching attempts to read the schema, they are now present!

