### PR TITLE
Use single schema file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.6.0
-erlang 20.3.8.9
+erlang 20.2.4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.6.0
-erlang 20.2.4
+erlang 20.3.8.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Changelog for ktsllex
 
+## 1.0.0
+
+- BREAKING: Use single file for avro key and value
+
 ## 0.0.3
 
-* Fixes for Lenses 2.1 API
+- Fixes for Lenses 2.1 API
 
 ## 0.0.2
 
-* Better error handling
-* Added Console logging
-* Fixed hex publishing
+- Better error handling
+- Added Console logging
+- Fixed hex publishing
 
 ## 0.0.1
 
-* Extract from private repo
-* Add licence
-* Add Travis CI
-* Publish to Hex
+- Extract from private repo
+- Add licence
+- Add Travis CI
+- Publish to Hex

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Ktsllex
 
 [![Build Status](https://travis-ci.org/quiqupltd/ktsllex.svg?branch=master)](https://travis-ci.org/quiqupltd/ktsllex)
-[![Coverage Status](https://coveralls.io/repos/github/quiqupltd/ktsllex/badge.svg?branch=master)](https://coveralls.io/github/quiqupltd/ktsllex?branch=master) 
-[![Hex docs](http://img.shields.io/badge/hex.pm-docs-green.svg?style=flat-square)](https://hexdocs.pm/ktsllex) 
-[![Hex Version](http://img.shields.io/hexpm/v/ktsllex.svg?style=flat-square)](https://hex.pm/packages/ktsllex) 
+[![Coverage Status](https://coveralls.io/repos/github/quiqupltd/ktsllex/badge.svg?branch=master)](https://coveralls.io/github/quiqupltd/ktsllex?branch=master)
+[![Hex docs](http://img.shields.io/badge/hex.pm-docs-green.svg?style=flat-square)](https://hexdocs.pm/ktsllex)
+[![Hex Version](http://img.shields.io/hexpm/v/ktsllex.svg?style=flat-square)](https://hex.pm/packages/ktsllex)
 [![License](https://img.shields.io/hexpm/l/ktsllex.svg?style=flat-square)](https://github.com/quiqupltd/ktsllex/blob/master/LICENSE.txt)
 
 Kafka Topic and Schema creator
@@ -11,6 +11,7 @@ Kafka Topic and Schema creator
 ## Setup
 
 Add `ktsllex` to your `deps` list :
+
 ```elixir
  {:ktsllex, "~> 0.0.2"},
 ```
@@ -49,8 +50,7 @@ And update config.exs
     lenses_topic: {:system, "LENSES_TOPIC", "topic_name"}
 ```
 
-* `base_path` - needs to be relitive to a path that is releasted with your app, eg `priv`
-
+- `base_path` - needs to be relitive to a path that is releasted with your app, eg `priv`
 
 ## Usage
 
@@ -63,7 +63,7 @@ $ mix create_topics --host=localhost:3030 --user=admin --password=admin --topic=
 
 ### Options
 
-* `--base`
+- `--base`
 
 The path to the schema files is passed into `mix create_schemas` via `--base=./path/to/schemas/json`.
 
@@ -77,10 +77,10 @@ mix create_schemas --base=./schemas/users
 
 Then there should be two flies in ./schemas:
 
-* `./schemas-key.json`
-* `./schemas-value.json`
+- `./schemas-key.json`
+- `./schemas-value.json`
 
-* `--schema`
+- `--schema`
 
 The `-key` and `-value` schemas get updated based on the `schema` parameter
 
@@ -142,8 +142,8 @@ If getting a topic that does not have a compatibility set, it will return this:
 
 ## Development
 
-* `mix deps.get`
-* `mix test`
+- `mix deps.get`
+- `mix test`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ mix create_topics --host=localhost:3030 --user=admin --password=admin --topic=
 
 The path to the schema files is passed into `mix create_schemas` via `--base=./path/to/schemas/json`.
 
-It expects to find two files there, one ending `-key.json` and one `-value.json`.
+It expects to find a single file there for the schema.
 
 Example: If this command was used:
 
@@ -75,14 +75,13 @@ Example: If this command was used:
 mix create_schemas --base=./schemas/users
 ```
 
-Then there should be two flies in ./schemas:
+Then there should be a single flie in ./schemas:
 
-- `./schemas-key.json`
-- `./schemas-value.json`
+- `./schemas.json`
 
 - `--schema`
 
-The `-key` and `-value` schemas get updated based on the `schema` parameter
+The schemas get updated based on the `schema` parameter
 
 Example: Given this `myschema` command :
 
@@ -90,14 +89,22 @@ Example: Given this `myschema` command :
 mix create_schemas --schema=myschema
 ```
 
-And if this is the `schemas-key.json` file :
+And if this is the `schemas.json` file :
 
 ```json
 {
-  "type": "record",
-  "name": "Key",
-  "namespace": "anything",
-  "connect.name": "anything.Key"
+  "name": "test",
+  "key_avro_schema": {
+    "type": "record",
+    "name": "Key",
+    "namespace": "anything",
+    "connect.name": "anything.Key"
+  },
+  "value_avro_schema": {
+    "type": "record",
+    "name": "Envelope",
+    "namespace": "anything"
+  }
 }
 ```
 
@@ -105,10 +112,18 @@ Then it would be updated to
 
 ```json
 {
-  "type": "record",
-  "name": "Key",
-  "namespace": "myschema",
-  "connect.name": "myschema.Key"
+  "name": "test",
+  "key_avro_schema": {
+    "type": "record",
+    "name": "Key",
+    "namespace": "myschema",
+    "connect.name": "myschema.Key"
+  },
+  "value_avro_schema": {
+    "type": "record",
+    "name": "Envelope",
+    "namespace": "myschema"
+  }
 }
 ```
 

--- a/lib/ktsllex/schemas.ex
+++ b/lib/ktsllex/schemas.ex
@@ -59,10 +59,8 @@ defmodule Ktsllex.Schemas do
       }"
     )
 
-    IO.inspect(
-      ["key", "value"]
-      |> Enum.map(fn type -> process(host, schema_name, base_schema_file, type) end)
-    )
+    ["key", "value"]
+    |> Enum.map(fn type -> process(host, schema_name, base_schema_file, type) end)
   end
 
   defp process(host, schema_name, base_schema_file, type) do
@@ -123,7 +121,6 @@ defmodule Ktsllex.Schemas do
           "key" -> key_schema
           "value" -> value_schema
         end
-
       _ ->
         {:error, :enoent}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ktsllex.MixProject do
   def project do
     [
       app: :ktsllex,
-      version: "0.0.2",
+      version: "1.0.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/schemas/test-key.json
+++ b/schemas/test-key.json
@@ -1,6 +1,0 @@
-{
-  "type": "record",
-  "name": "Key",
-  "namespace": "anything",
-  "connect.name": "anything.Key"
-}

--- a/schemas/test-value.json
+++ b/schemas/test-value.json
@@ -1,5 +1,0 @@
-{
-  "type": "record",
-  "name": "Envelope",
-  "namespace": "anything"
-}

--- a/schemas/test.json
+++ b/schemas/test.json
@@ -1,0 +1,14 @@
+{
+  "name": "test",
+  "key_avro_schema": {
+    "type": "record",
+    "name": "Key",
+    "namespace": "anything",
+    "connect.name": "anything.Key"
+  },
+  "value_avro_schema": {
+    "type": "record",
+    "name": "Envelope",
+    "namespace": "anything"
+  }
+}

--- a/test/ktsllex/schemas_test.exs
+++ b/test/ktsllex/schemas_test.exs
@@ -1,7 +1,7 @@
 defmodule Ktsllex.SchemasTest do
   use ExUnit.Case, async: true
 
-  alias Ktsllex.Schemas, as: Subject
+  alias Ktsllex.Schemas, as: Schemas
 
   defmodule HTTPoisonMock do
     def post(url, body, headers) do
@@ -18,12 +18,12 @@ defmodule Ktsllex.SchemasTest do
   end
 
   setup do
-    config = Application.get_env(:ktsllex, Subject)
+    config = Application.get_env(:ktsllex, Schemas)
 
-    Application.put_env(:ktsllex, Subject, http_client: HTTPoisonMock)
+    Application.put_env(:ktsllex, Schemas, http_client: HTTPoisonMock)
 
     on_exit(fn ->
-      Application.put_env(:ktsllex, Subject, config)
+      Application.put_env(:ktsllex, Schemas, config)
     end)
 
     Process.register(self(), :current_test)
@@ -78,7 +78,7 @@ defmodule Ktsllex.SchemasTest do
         headers: headers
       }
 
-      assert [:ok, :ok] == Subject.run(host, schema_name, base_schema_file)
+      assert [:ok, :ok] == Schemas.run(host, schema_name, base_schema_file)
       assert_receive ^key_result
       assert_receive ^value_result
       refute_receive _
@@ -89,7 +89,7 @@ defmodule Ktsllex.SchemasTest do
       schema_name = "schema_name"
       base_schema_file = "./schemas/not-found"
 
-      assert [:error, :error] == Subject.run(host, schema_name, base_schema_file)
+      assert [:error, :error] == Schemas.run(host, schema_name, base_schema_file)
       refute_receive _
     end
   end


### PR DESCRIPTION
Update to use a single file format as we are starting to use internally. Instead of two files test-key.json and test-value.json we have a single file test.json which has both concerns

```
{
  "name": "test",
  "key_avro_schema": {
    "type": "record",
    "name": "Key",
    "namespace": "anything",
    "connect.name": "anything.Key"
  },
  "value_avro_schema": {
    "type": "record",
    "name": "Envelope",
    "namespace": "anything"
  }
}

```